### PR TITLE
@sveltejs/adapter-static version update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.9",
             "license": "ISC",
             "dependencies": {
-                "@sveltejs/adapter-static": "1.0.0-next.34",
+                "@sveltejs/adapter-static": "1.0.0-next.38",
                 "yaml": "^2.1.1"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
             "version": "0.0.9",
             "license": "ISC",
             "dependencies": {
-                "@sveltejs/adapter-static": "1.0.0-next.38",
+                "@sveltejs/adapter-static": "^1.0.0-next.38",
                 "yaml": "^2.1.1"
             }
         },
         "node_modules/@sveltejs/adapter-static": {
-            "version": "1.0.0-next.34",
-            "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.34.tgz",
-            "integrity": "sha512-XjuMhemme5z0L/B2nTZpA6k+RJjF+b6L96ts6gIQ6ixiCzJQSbBqJhrrBYBCaeLAKvdUMoGEmX8m862JhKjRFg==",
+            "version": "1.0.0-next.38",
+            "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.38.tgz",
+            "integrity": "sha512-O1b264K62E3OrUnsFxMjKn3CUJF50fxGcW0rWk8fa5kjzskPsSyTxS3jnWNryFaVJ3oSUtx57m4qFW43S1910Q==",
             "dependencies": {
                 "tiny-glob": "^0.2.9"
             }
@@ -51,9 +51,9 @@
     },
     "dependencies": {
         "@sveltejs/adapter-static": {
-            "version": "1.0.0-next.34",
-            "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.34.tgz",
-            "integrity": "sha512-XjuMhemme5z0L/B2nTZpA6k+RJjF+b6L96ts6gIQ6ixiCzJQSbBqJhrrBYBCaeLAKvdUMoGEmX8m862JhKjRFg==",
+            "version": "1.0.0-next.38",
+            "resolved": "https://registry.npmjs.org/@sveltejs/adapter-static/-/adapter-static-1.0.0-next.38.tgz",
+            "integrity": "sha512-O1b264K62E3OrUnsFxMjKn3CUJF50fxGcW0rWk8fa5kjzskPsSyTxS3jnWNryFaVJ3oSUtx57m4qFW43S1910Q==",
             "requires": {
                 "tiny-glob": "^0.2.9"
             }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "types": "index.d.ts",
     "license": "ISC",
     "dependencies": {
-        "@sveltejs/adapter-static": "1.0.0-next.34",
+        "@sveltejs/adapter-static": "1.0.0-next.38",
         "yaml": "^2.1.1"
     },
     "directories": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "types": "index.d.ts",
     "license": "ISC",
     "dependencies": {
-        "@sveltejs/adapter-static": "1.0.0-next.38",
+        "@sveltejs/adapter-static": "^1.0.0-next.38",
         "yaml": "^2.1.1"
     },
     "directories": {


### PR DESCRIPTION
In order to fix the writeStatic error with the current version you'll need to use the most up-to-date version of @sveltejs/adapter-static which is 1.0.0-next.38

updated 1.0.0-next.34 > 1.0.0-next.38